### PR TITLE
Implemented customBuilder

### DIFF
--- a/file_icon/lib/file_icon.dart
+++ b/file_icon/lib/file_icon.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/widgets.dart';
 import 'src/data.dart';
 
+typedef CustomBuilder = Widget? Function(String? key, Icon icon);
+
 class FileIcon extends StatelessWidget {
   final String fileName;
-  final double size;
+  final double? size;
 
-  FileIcon(String fileName, {this.size})
-      : this.fileName = fileName.toLowerCase();
+  /// This color will override the color provided from Seti icons
+  final Color? color;
+
+  /// Use this widget to render custom widget by checking the key.
+  /// It returns recognized file extension as a [key], and [icon] widget which will be rendered.
+  /// This can be used to show custom icon when file type is unknown ([key] is null)
+  final CustomBuilder? customBuilder;
+
+  FileIcon(String fileName, {this.size, this.color, this.customBuilder}) : this.fileName = fileName.toLowerCase();
 
   @override
   Widget build(BuildContext context) {
-    String key;
+    String? key;
 
     if (iconSetMap.containsKey(fileName)) {
       key = fileName;
@@ -26,18 +35,16 @@ class FileIcon extends StatelessWidget {
       }
     }
 
-    if (key == null) {
-      key = '.txt';
-    }
-
-    return Icon(
+    final Icon iconWidget = Icon(
       IconData(
-        iconSetMap[key].codePoint,
+        iconSetMap[key ?? '.txt']!.codePoint,
         fontFamily: 'Seti',
         fontPackage: 'file_icon',
       ),
-      color: Color(iconSetMap[key].color),
+      color: color ?? Color(iconSetMap[key ?? '.txt']!.color),
       size: size,
     );
+
+    return customBuilder != null ? (customBuilder!(key, iconWidget) ?? iconWidget) : iconWidget;
   }
 }


### PR DESCRIPTION
`customBuilder` allows to modify the widget being rendered, apply some effects to it, or provide custom icon for specific file types.

This pull request also includes ability to override icon color from [@zagronitay](https://github.com/git-touch/file-icon/pull/4), as well as patches for null-safety support